### PR TITLE
COMMENT API 경로 및 컨트롤러 이름 수정

### DIFF
--- a/api/comment.ts
+++ b/api/comment.ts
@@ -2,8 +2,8 @@ import { Router } from "express";
 import comment from "@/controller/comment";
 const route = Router();
 
-route.post("/comment/:todo_id", comment.create);
-route.put("/comment/:todo_id", comment.update);
-route.delete("/comment/:todo_id", comment.destroy);
+route.post("/:todo_id", comment.create);
+route.put("/:todo_id", comment.update);
+route.delete("/:todo_id", comment.destroy);
 
 export default route;

--- a/api/comment.ts
+++ b/api/comment.ts
@@ -2,8 +2,8 @@ import { Router } from "express";
 import comment from "@/controller/comment";
 const route = Router();
 
-route.post("/:todo_id", comment.create);
-route.put("/:todo_id", comment.update);
+route.post("/:todo_id", comment.post);
+route.put("/:todo_id", comment.put);
 route.delete("/:todo_id", comment.destroy);
 
 export default route;

--- a/controller/comment.ts
+++ b/controller/comment.ts
@@ -3,13 +3,13 @@ import db from "@/models";
 import { isLogin } from "@/utils";
 
 export default {
-  create,
-  update,
+  post,
+  put,
   destroy,
 };
 
 // comment생성
-async function create(req: Request, res: Response) {
+async function post(req: Request, res: Response) {
   try {
     const user_id = await isLogin(req, res);
     if (!user_id) return res.redirect("/login");
@@ -33,7 +33,7 @@ async function create(req: Request, res: Response) {
 }
 
 // comment수정
-async function update(req: Request, res: Response) {
+async function put(req: Request, res: Response) {
   try {
     const user_id = await isLogin(req, res);
     if (!user_id) return res.redirect("/login");

--- a/routes/comment.ts
+++ b/routes/comment.ts
@@ -3,7 +3,7 @@ import todo from "@/controller/comment";
 
 const route = Router();
 //투두 comment
-route.post("/:year/:month/:day/comment", todo.create);
-route.put("/:year/:month/:day/comment", todo.update);
+route.post("/:year/:month/:day/comment", todo.post);
+route.put("/:year/:month/:day/comment", todo.put);
 route.delete("/:year/:month/:day/comment", todo.destroy);
 export default route;


### PR DESCRIPTION
- COMMENT API 경로 
  - 기존 경로는 `/todo/comment/comment/:todo_id`로 `comment`가 두 번이나 반복됨
  - 이를 수정해서 현재는 `/todo/comment/:todo_id`로 사용 가능
- COMMENT 컨트롤러 이름 수정
  - create -> post
  - update -> put